### PR TITLE
Finish implementing tests for `src`.

### DIFF
--- a/lib/src.js
+++ b/lib/src.js
@@ -10,68 +10,20 @@ var _ = require('lodash'),
 
 
 // So would love to use the `request` module but it doesn't support
-// streams2 soooo... ¯\_(ツ)_/¯
+// streams2+ soooo... ¯\_(ツ)_/¯
 
 var handlers = {
 	'http:': require('http'),
 	'https:': require('https')
 };
 
-/**
- * Like `request` but with streams2.
- *
- * @param {Object} options Parameters.
- * @param {Function} callback Called when done.
- * @returns {Object} Request object generated.
- *
- * @see https://github.com/request/request/issues/1242
- */
-function request(options, callback) {
-	var parts = url.parse(options.url);
-
-	if (!_.has(handlers, parts.protocol)) {
-		callback(new TypeError());
-		return null;
-	}
-
-	var req = handlers[parts.protocol].request({
-		method: options.method || 'GET',
-		hostname: parts.hostname,
-		port: parts.port,
-		path: parts.path
-	}, function responded(res) {
-		if (options.buffer) {
-			var result = [ ];
-			res.on('readable', function readable() {
-				var chunk;
-				while ((chunk = this.read()) !== null) {
-					result.push(chunk);
-				}
-			}).on('end', function end() {
-				callback(null, res, Buffer.concat(result));
-			}).on('error', function error(err) {
-				callback(err);
-			});
-		} else {
-			callback(null, res, res);
-		}
-	});
-
-	req.on('error', function error(err){
-		callback(err);
-	});
-
-	req.end();
-
-	return req;
-}
 
 /**
  *
  * @constructor
- * @param {Array} urls
- * @param {Object} opts
- * @param {Object} streamOpts 
+ * @param {Array} urls List of urls to read
+ * @param {Object} opts Options for the URLs
+ * @param {Object} streamOpts Options for the stream constructor
  */
 function ReadStream(urls, opts, streamOpts) {
 	if (this instanceof ReadStream === false) {
@@ -81,7 +33,7 @@ function ReadStream(urls, opts, streamOpts) {
 	Stream.Readable.call(this, _.assign({ }, streamOpts, { objectMode: true }));
 
 	// Basic type safety
-	if (!_.isObject(urls) || !_.isString(urls)) {
+	if (!_.isObject(urls) && !_.isString(urls)) {
 		throw new TypeError();
 	}
 
@@ -102,6 +54,56 @@ function ReadStream(urls, opts, streamOpts) {
 }
 util.inherits(ReadStream, Stream.Readable);
 
+
+/**
+ * Like `request` but with streams2.
+ *
+ * @param {Object} options Parameters.
+ * @param {Function} callback Called when done.
+ * @returns {Object} Request object generated.
+ *
+ * @see https://github.com/request/request/issues/1242
+ */
+ReadStream.request = function request(options, callback) {
+	var parts = url.parse(options.url);
+
+	if (!_.has(handlers, parts.protocol)) {
+		callback(new TypeError());
+		return null;
+	}
+
+	var req = handlers[parts.protocol].request({
+		method: options.method,
+		hostname: parts.hostname,
+		port: parts.port,
+		path: parts.path
+	});
+
+	req.on('response', function responded(res) {
+		if (options.buffer) {
+			var result = [ ];
+			res.on('readable', function readable() {
+				var chunk;
+				while ((chunk = this.read()) !== null) {
+					result.push(chunk);
+				}
+			}).on('end', function end() {
+				callback(null, req, res, Buffer.concat(result));
+			}).on('error', function error(err) {
+				callback(err);
+			});
+		} else {
+			callback(null, req, res, res);
+		}
+	}).on('error', function error(err){
+		callback(err);
+	});
+
+	req.end();
+
+	return req;
+};
+
 /**
  * Fetch the URL and emit it as vinyl.
  * @param {String|Object} url URL to process.
@@ -110,7 +112,7 @@ util.inherits(ReadStream, Stream.Readable);
 ReadStream.prototype.processUrl = function processUrl(url) {
 	var self = this;
 
-	function done(err, response, body) {
+	function done(err, req, res, body) {
 		// Request is done!
 		--self.pending;
 
@@ -120,7 +122,7 @@ ReadStream.prototype.processUrl = function processUrl(url) {
 			return;
 		}
 
-		if (response.statusCode < 200 || response.statusCode >= 300) {
+		if (res.statusCode < 200 || res.statusCode >= 300) {
 			self.emit('error', { error: 'NON_OK_STATUS_CODE' });
 			return;
 		}
@@ -129,13 +131,12 @@ ReadStream.prototype.processUrl = function processUrl(url) {
 		// Support for Content-Disposition filename parameter
 		// e.g. Content-Disposition: attachment; filename=foo.jpg
 
-
 		// Turn the result into vinyl
 		var file = new File({
 			contents: self.options.read ? body : null,
-			path: response.req.path,
+			path: req.path,
 			pwd: self.options.cwd,
-			base: path.dirname(response.req.path)
+			base: path.dirname(req.path)
 		});
 
 		// Output the vinyl
@@ -150,7 +151,7 @@ ReadStream.prototype.processUrl = function processUrl(url) {
 	var options = _.assign({ url: url }, self.options);
 	++self.pending;
 
-	request(options, done);
+	ReadStream.request(options, done);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	},
 	"scripts": {
 		"test": "npm run lint && npm run spec && npm run coverage",
-		"spec": "NODE_PATH=lib NODE_ENV=test istanbul cover node_modules/.bin/_mocha -- -r test/helpers/chai -R spec test/spec",
+		"spec": "NODE_PATH=lib NODE_ENV=test istanbul cover node_modules/.bin/_mocha -- -r test/helpers/chai -r test/helpers/sinon -R spec test/spec",
 		"lint": "eslint --ignore-path .gitignore .",
 		"coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
 	},
@@ -28,6 +28,7 @@
 		"chai": "*",
 		"chai-things": "*",
 		"sinon": "*",
-		"sinon-chai": "*"
+		"sinon-chai": "*",
+		"through2": "*"
 	}
 }

--- a/test/spec/dest.spec.js
+++ b/test/spec/dest.spec.js
@@ -1,0 +1,10 @@
+
+'use strict';
+
+var dest = require('dest');
+
+describe('dest', function() {
+	it('should fail with no urls', function() {
+		expect(dest).to.throw(TypeError);
+	});
+});

--- a/test/spec/src.spec.js
+++ b/test/spec/src.spec.js
@@ -1,10 +1,137 @@
 
 'use strict';
 
-var src = require('src');
+var src = require('src'),
+	http = require('http'),
+	through2 = require('through2');
+
+
 
 describe('src', function() {
+
+	function pair(opts) {
+		var req = through2(),
+			res = through2();
+		req.path = opts.path;
+		req.on('finish', function() {
+			res.statusCode = opts.statusCode;
+			req.emit('response', res);
+			if (opts.error) {
+				res.emit('error', opts.error);
+			} else {
+				res.end(opts.data || new Buffer(1024));
+			}
+		});
+
+		return req;
+	}
+
+	beforeEach(function() {
+		this.sandbox = sinon.sandbox.create();
+		this.sandbox.stub(http, 'request');
+	});
+
+	afterEach(function() {
+		this.sandbox.restore();
+	});
+
 	it('should fail with no urls', function() {
 		expect(src).to.throw(TypeError);
+	});
+
+	it('should work with single url string', function() {
+		src('http://www.google.com');
+	});
+
+	it('should work with array of strings', function() {
+		src(['http://www.google.com', 'http://www.google.ca']);
+	});
+
+	it('should emit error with a non-ok http status code', function(done) {
+		http.request.returns(pair({ statusCode: 400, path: '/test' }));
+		src('http://www.google.com').once('error', function(err) {
+			expect(err).to.deep.equal({ error: 'NON_OK_STATUS_CODE' });
+			done();
+		}).read();
+	});
+
+	it('should default to HEAD if `read` is false', function() {
+		http.request.returns(pair({ statusCode: 200, path: '/test' }));
+		src('http://www.google.com', { read: false }).read();
+		expect(http.request).to.be.calledWithMatch({ method: 'HEAD' });
+	});
+
+	it('should buffer data if `buffer` is true', function(done) {
+		http.request.returns(pair({ statusCode: 200, path: '/test' }));
+		src('http://www.google.com', { buffer: true })
+			.once('readable', function() {
+				var file = this.read();
+				expect(file.isBuffer()).to.be.true;
+				done();
+			})
+			.read(0);
+	});
+
+	it('should stream data if `buffer` is false', function(done) {
+		http.request.returns(pair({ statusCode: 200, path: '/test' }));
+		src('http://www.google.com', { buffer: false })
+			.once('readable', function() {
+				var file = this.read();
+				expect(file.isStream()).to.be.true;
+				done();
+			})
+			.read(0);
+	});
+
+	it('should end after last url', function(done) {
+		http.request
+			.onFirstCall().returns(pair({ statusCode: 200, path: '/foo' }))
+			.onSecondCall().returns(pair({ statusCode: 200, path: '/bar' }));
+
+		src(['http://www.google.com', 'http://www.google.com'])
+			.on('readable', function() {
+				this.read();
+			})
+			.once('end', done)
+			.read(0);
+	});
+
+	it('should fail for urls without handlers', function(done) {
+		src('foo://bar').once('error', function(err) {
+			expect(err).to.be.an.instanceof(TypeError);
+			done();
+		}).read();
+	});
+
+	it('should obey explicit http method', function() {
+		http.request.returns(pair({ statusCode: 200, path: '/test' }));
+		src('http://www.google.com', { method: 'POST' }).read();
+		expect(http.request).to.be.calledWithMatch({
+			method: 'POST'
+		});
+	});
+
+	it('should pass up request errors', function(done) {
+		var req = pair({ statusCode: 200, path: '/test' });
+		http.request.returns(req);
+		src('http://www.google.com')
+			.once('error', function(err) {
+				expect(err).to.equal('lol');
+				done();
+			})
+			.read();
+		req.emit('error', 'lol');
+	});
+
+	it('should pass up response errors', function(done) {
+		http.request.returns(pair({
+			statusCode: 200, path: '/test', error: 'lol'
+		}));
+		src('http://www.google.com', { method: 'POST' })
+			.once('error', function(err) {
+				expect(err).to.equal('lol');
+				done();
+			})
+			.read();
 	});
 });


### PR DESCRIPTION
This gets us up to 100% code coverage with reasonable expectations about what's going on in the library. It also mildly refactors the `request` method to be a part of the static scope of `ReadStream`.
