### PR TITLE
Add gulp example to readme showing how to use the library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ Turn HTTP requests into vinyl.
 ![license](http://img.shields.io/npm/l/vinyl-request.svg?style=flat)
 ![version](http://img.shields.io/npm/v/vinyl-request.svg?style=flat)
 ![downloads](http://img.shields.io/npm/dm/vinyl-request.svg?style=flat)
+
+Now you can use HTTP requests as if they were vinyl!
+
+```javascript
+var gulp = require('gulp'),
+	http = require('vinyl-request');
+
+gulp.task('download', function() {
+	return http.src('http://i.imgur.com/XHx0XLw.jpg')
+		.pipe(gulp.dest('downloads'));
+});
+```


### PR DESCRIPTION
As README.md is the first place people looking, it makes sense to provide a brief overview about how to use the library.
